### PR TITLE
Userのfactorybotで、userに関連するarticleも生成可能にした

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    content { "MyText" }
-    user { nil }
+    title { Faker::Movie.quote }
+    content { Faker::Quote.famous_last_words }
+    user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:email) { |n| "#{n}_" + Faker::Internet.email }
     password { Faker::Internet.password(8) }
 
-    trait :with_article do
+    trait :with_articles do
       transient do
         article_count {5}
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,18 @@ FactoryBot.define do
     name { Faker::Name.name }
     sequence(:email) { |n| "#{n}_" + Faker::Internet.email }
     password { Faker::Internet.password(8) }
+
+    trait :with_article do
+      transient do
+        article_count {5}
+      end
+
+      after(:create) do |user, evaluator|
+        evaluator.article_count.times do
+          create(:article, user: user)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
・traitの使用。デフォルトでuserに関連する５つのarticleが生成される
・spec/factories/articles.rbの修正（PRで分けるべきですね汗）