### PR TITLE
FactoryBotでarticler_likeのtrait追加。user,articlesに関連するarticle_likeの生成可能。

### DIFF
--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
+    user
+    article
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,5 +23,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_article_like do
+      after(:create) do |user|
+        user_article = create(:article, user: user)
+        create(:article_like, user: user, article: user_article)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- spec/factories/article_likes.rbでuser, articleとの関連の修正
- spec/factories/users.rbでarticle_likeのtraitを記述