### PR TITLE
トップページとユーザー登録まわりのページのデザインを修正

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class HomesController < ApplicationController
-  def index; end
+  def index
+  end
 end

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Router from "./router/router";
 import Header from "./components/Header.vue";
 import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
 
 Vue.use(Vuetify);
 

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,9 +1,13 @@
 import Vue from 'vue/dist/vue.esm'
 import Router from './router/router'
+import Header from "./components/Header.vue";
 
 document.addEventListener('turbolinks:load', () => {
   new Vue({
     el: '#app',
     router: Router,
+    components: {
+      navbar: Header
+    }
   })
 })

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,8 +1,8 @@
-import Vue from 'vue/dist/vue.esm'
-import Router from './router/router'
+import Vue from "vue";
+import Router from "./router/router";
 import Header from "./components/Header.vue";
 
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener("turbolinks:load", () => {
   new Vue({
     el: '#app',
     router: Router,

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -7,7 +7,7 @@ Vue.use(Vuetify);
 
 document.addEventListener("turbolinks:load", () => {
   new Vue({
-    el: '#app',
+    el: "#app",
     router: Router,
     components: {
       navbar: Header

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,6 +1,9 @@
 import Vue from "vue";
 import Router from "./router/router";
 import Header from "./components/Header.vue";
+import Vuetify from "vuetify";
+
+Vue.use(Vuetify);
 
 document.addEventListener("turbolinks:load", () => {
   new Vue({

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -12,5 +12,5 @@ document.addEventListener("turbolinks:load", () => {
     components: {
       navbar: Header
     }
-  })
-})
+  });
+});

--- a/app/javascript/packs/components/ArticlesComponent.vue
+++ b/app/javascript/packs/components/ArticlesComponent.vue
@@ -1,0 +1,29 @@
+<template>
+  <div id="articles-container">
+    <ul>
+      <li v-for="article in articles" v-bind:key="article.id">
+        <div>{{article.title}}</div>
+        <div>{{article.content}}</div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+@Component
+export default class ArticlesComponent extends Vue {
+  articles: String[] = [];
+  async mounted(): Promise<void> {
+    await this.fetchArticles();
+  }
+  async fetchArticles(): Promise<void> {
+    await axios.get("/api/v1/articles").then(response => {
+      response.data.map((article: any) => {
+        this.articles.push(article);
+      });
+    });
+  }
+}
+</script>

--- a/app/javascript/packs/components/ArticlesComponent.vue
+++ b/app/javascript/packs/components/ArticlesComponent.vue
@@ -12,12 +12,15 @@
 <script lang="ts">
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
+
 @Component
 export default class ArticlesComponent extends Vue {
-  articles: String[] = [];
+  articles: string[] = [];
+
   async mounted(): Promise<void> {
     await this.fetchArticles();
   }
+
   async fetchArticles(): Promise<void> {
     await axios.get("/api/v1/articles").then(response => {
       response.data.map((article: any) => {

--- a/app/javascript/packs/components/Header.vue
+++ b/app/javascript/packs/components/Header.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>へっだー</div>
+</template>

--- a/app/javascript/packs/components/Header.vue
+++ b/app/javascript/packs/components/Header.vue
@@ -20,7 +20,7 @@
       <router-link to="/sign_up" class="header-link">
         <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
       </router-link>
-      <router-link to="/" class="header-link">
+      <router-link to="/sign_in" class="header-link">
         <v-btn flat class="font-weight-bold">ログイン</v-btn>
       </router-link>
     </div>

--- a/app/javascript/packs/components/Header.vue
+++ b/app/javascript/packs/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <v-toolbar dark color="#55c500">
     <router-link to="/" class="header-link">
-      <v-toolbar-title class="white--text">Qiita</v-toolbar-title>
+      <v-toolbar-title class="white--text font-weight-bold">Qiita</v-toolbar-title>
     </router-link>
 
     <!-- <v-btn icon>
@@ -10,23 +10,78 @@
 
     <v-spacer></v-spacer>
 
-    <router-link to="/sign_up" class="header-link">
-      <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
-    </router-link>
-    <router-link to="/" class="header-link">
-      <v-btn flat class="font-weight-bold">ログイン</v-btn>
-    </router-link>
+    <div v-if="isLoggedIn">
+      <router-link to="/articles/new" class="header-link">
+        <v-btn flat class="post font-weight-bold">投稿する</v-btn>
+      </router-link>
+      <v-btn flat @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+    </div>
+    <div v-else>
+      <router-link to="/sign_up" class="header-link">
+        <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
+      </router-link>
+      <router-link to="/" class="header-link">
+        <v-btn flat class="font-weight-bold">ログイン</v-btn>
+      </router-link>
+    </div>
   </v-toolbar>
 </template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+@Component
+export default class Header extends Vue {
+  isLoggedIn: boolean = !!localStorage.getItem("access-token");
+
+  async logout(): Promise<void> {
+    await axios
+      .delete("/api/v1/auth/sign_out", headers)
+      .then(_response => {
+        this.refresh();
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors);
+
+        // localStorage は残っているが、
+        // ログアウトはしてしまっている状態なのですべてリセットする
+        this.refresh();
+      });
+  }
+
+  private refresh(): void {
+    localStorage.clear();
+    Router.push("/");
+    // TODO: Vuex でログイン状態を管理するようになったら消す
+    window.location.reload();
+  }
+}
+</script>
 
 <style lang="scss" scoped>
 .header-link {
   text-decoration: none;
 }
-.register {
+
+.register,
+.post {
   border: 2px solid #fff;
   border-radius: 5px;
 }
+
 .login {
   font-weight: bold;
 }

--- a/app/javascript/packs/components/Header.vue
+++ b/app/javascript/packs/components/Header.vue
@@ -1,3 +1,34 @@
 <template>
-  <div>へっだー</div>
+  <v-toolbar dark color="#55c500">
+    <router-link to="/" class="header-link">
+      <v-toolbar-title class="white--text">Qiita</v-toolbar-title>
+    </router-link>
+
+    <!-- <v-btn icon>
+      <v-icon>search</v-icon>
+    </v-btn>-->
+
+    <v-spacer></v-spacer>
+
+    <router-link to="/" class="header-link">
+      <v-btn flat class="register">ユーザー登録</v-btn>
+    </router-link>
+    <router-link to="/" class="header-link">
+      <v-btn flat class="login">ログイン</v-btn>
+    </router-link>
+  </v-toolbar>
 </template>
+
+<style lang="scss" scoped>
+.header-link {
+  text-decoration: none;
+}
+.register {
+  border: 2px solid #fff;
+  border-radius: 5px;
+  font-weight: bold;
+}
+.login {
+  font-weight: bold;
+}
+</style>

--- a/app/javascript/packs/components/Header.vue
+++ b/app/javascript/packs/components/Header.vue
@@ -10,11 +10,11 @@
 
     <v-spacer></v-spacer>
 
-    <router-link to="/" class="header-link">
-      <v-btn flat class="register">ユーザー登録</v-btn>
+    <router-link to="/sign_up" class="header-link">
+      <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
     </router-link>
     <router-link to="/" class="header-link">
-      <v-btn flat class="login">ログイン</v-btn>
+      <v-btn flat class="font-weight-bold">ログイン</v-btn>
     </router-link>
   </v-toolbar>
 </template>
@@ -26,7 +26,6 @@
 .register {
   border: 2px solid #fff;
   border-radius: 5px;
-  font-weight: bold;
 }
 .login {
   font-weight: bold;

--- a/app/javascript/packs/components/LoginComponent.vue
+++ b/app/javascript/packs/components/LoginComponent.vue
@@ -1,0 +1,75 @@
+<template>
+  <form>
+    <v-text-field
+      v-model="email"
+      v-validate="'required|email'"
+      :error-messages="errors.collect('email')"
+      label="メールアドレス"
+      data-vv-name="email"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="password"
+      :append-icon="show ? 'visibility' : 'visibility_off'"
+      :type="show ? 'text' : 'password'"
+      v-validate="'required|min:8|max:50'"
+      :error-messages="errors.collect('password')"
+      name="password"
+      label="パスワード"
+      hint="At least 8 characters"
+      counter
+      @click:append="show = !show"
+    ></v-text-field>
+
+    <v-btn @click="submit" color="#55c500" class="white--text font-weight-bold">ログイン</v-btn>
+  </form>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import VeeValidate from "vee-validate";
+import Router from "../router/router";
+Vue.use(VeeValidate, { locale: "ja" });
+@Component
+export default class RegisterComponent extends Vue {
+  $_veeValidate: {
+    validator: "new";
+  };
+  email: string = "";
+  show: boolean = false;
+  password: string = "";
+  dictionary: {
+    attributes: {
+      email: "Email Addresss";
+    };
+  };
+  mounted() {
+    this.$validator.localize("ja", this.dictionary);
+  }
+  async submit(): Promise<void> {
+    // this.$validator.validateAll();
+    const params = {
+      email: this.email,
+      password: this.password
+    };
+    await axios
+      .post("/api/v1/auth/sign_in", params)
+      .then(response => {
+        localStorage.setItem("access-token", response.headers["access-token"]);
+        localStorage.setItem("uid", response.headers["uid"]);
+        localStorage.setItem("client", response.headers["client"]);
+        Router.push("/");
+        // TODO: Vuex でログイン状態を管理するようになったら消す
+        window.location.reload();
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors.full_messages);
+      });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/app/javascript/packs/components/RegisterComponent.vue
+++ b/app/javascript/packs/components/RegisterComponent.vue
@@ -5,8 +5,8 @@
       v-validate="'required|max:10'"
       :counter="10"
       :error-messages="errors.collect('name')"
-      label="Name"
-      data-vv-name="ユーザー名"
+      label="ユーザー名"
+      data-vv-name="name"
       required
     ></v-text-field>
     <v-text-field
@@ -70,7 +70,7 @@ export default class RegisterComponent extends Vue {
 
   async submit(): Promise<void> {
    // this.$validator.validateAll();
-        const params = {
+      const params = {
       name: this.name,
       email: this.email,
       password: this.password

--- a/app/javascript/packs/components/RegisterComponent.vue
+++ b/app/javascript/packs/components/RegisterComponent.vue
@@ -65,11 +65,11 @@ export default class RegisterContainer extends Vue {
   };
 
   mounted() {
-    this.$validator.localize("en", this.dictionary);
+    this.$validator.localize("ja", this.dictionary);
   }
 
   async submit(): Promise<void> {
-    this.$validator.validateAll();
+   // this.$validator.validateAll();
         const params = {
       name: this.name,
       email: this.email,
@@ -78,11 +78,19 @@ export default class RegisterContainer extends Vue {
 
     await axios
       .post("/api/v1/auth", params)
-      .then(_response => {
+      .then(response => {
+        localStorage.setItem("access-token", response.headers["access-token"]);
+        localStorage.setItem("uid", response.headers["uid"]);
+        localStorage.setItem("client", response.headers["client"]);
+
         Router.push("/");
+
+        // TODO: Vuex でログイン状態を管理するようになったら消す
+        window.location.reload();
       })
-      .catch(error => {
-        alert(error);
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors.full_messages);
       });
   }
   // clear() {

--- a/app/javascript/packs/components/RegisterComponent.vue
+++ b/app/javascript/packs/components/RegisterComponent.vue
@@ -35,8 +35,10 @@
 </template>
 
 <script lang="ts">
+import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import VeeValidate from "vee-validate";
+import Router from "../router/router";
 
 Vue.use(VeeValidate, { locale: "ja" });
 
@@ -66,14 +68,29 @@ export default class RegisterContainer extends Vue {
     this.$validator.localize("en", this.dictionary);
   }
 
-  submit() {
+  async submit(): Promise<void> {
     this.$validator.validateAll();
+        const params = {
+      name: this.name,
+      email: this.email,
+      password: this.password
+    };
+
+    await axios
+      .post("/api/v1/auth", params)
+      .then(_response => {
+        Router.push("/");
+      })
+      .catch(error => {
+        alert(error);
+      });
   }
-  clear() {
-    this.name = "";
-    this.email = "";
-    this.$validator.reset();
-  }
+  // clear() {
+  //   this.name = "";
+  //   this.email = "";
+  //   this.password = "";
+  //   this.$validator.reset();
+  // }
 }
 </script>
 

--- a/app/javascript/packs/components/RegisterComponent.vue
+++ b/app/javascript/packs/components/RegisterComponent.vue
@@ -1,12 +1,12 @@
 <template>
   <form>
     <v-text-field
-      v-model="ユーザー名"
+      v-model="name"
       v-validate="'required|max:10'"
       :counter="10"
       :error-messages="errors.collect('name')"
       label="Name"
-      data-vv-name="name"
+      data-vv-name="ユーザー名"
       required
     ></v-text-field>
     <v-text-field
@@ -43,7 +43,7 @@ import Router from "../router/router";
 Vue.use(VeeValidate, { locale: "ja" });
 
 @Component
-export default class RegisterContainer extends Vue {
+export default class RegisterComponent extends Vue {
   $_veeValidate: {
     validator: "new";
   };

--- a/app/javascript/packs/components/RegisterComponent.vue
+++ b/app/javascript/packs/components/RegisterComponent.vue
@@ -1,0 +1,81 @@
+<template>
+  <form>
+    <v-text-field
+      v-model="ユーザー名"
+      v-validate="'required|max:10'"
+      :counter="10"
+      :error-messages="errors.collect('name')"
+      label="Name"
+      data-vv-name="name"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="email"
+      v-validate="'required|email'"
+      :error-messages="errors.collect('email')"
+      label="メールアドレス"
+      data-vv-name="email"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="password"
+      :append-icon="show ? 'visibility' : 'visibility_off'"
+      :type="show ? 'text' : 'password'"
+      v-validate="'required|min:8|max:50'"
+      :error-messages="errors.collect('password')"
+      name="password"
+      label="パスワード"
+      hint="At least 8 characters"
+      counter
+      @click:append="show = !show"
+    ></v-text-field>
+
+    <v-btn @click="submit" color="#55c500" class="white--text font-weight-bold">登録</v-btn>
+  </form>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from "vue-property-decorator";
+import VeeValidate from "vee-validate";
+
+Vue.use(VeeValidate, { locale: "ja" });
+
+@Component
+export default class RegisterContainer extends Vue {
+  $_veeValidate: {
+    validator: "new";
+  };
+
+  name: string = "";
+  email: string = "";
+  show: boolean = false;
+  password: string = "";
+  dictionary: {
+    attributes: {
+      email: "Email Addresss";
+    };
+    custom: {
+      name: {
+        required: () => "Name can not be empty";
+        max: "The name field may not be greater than 10 characters";
+      };
+    };
+  };
+
+  mounted() {
+    this.$validator.localize("en", this.dictionary);
+  }
+
+  submit() {
+    this.$validator.validateAll();
+  }
+  clear() {
+    this.name = "";
+    this.email = "";
+    this.$validator.reset();
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,7 +1,8 @@
 import Vue from 'vue/dist/vue.esm.js'
 import VueRouter from 'vue-router'
-import ArticlesConmponent from '../components/ArticlesConmponent.vue'
-import RegisterConmponent from "../components/RegisterConmponent.vue";
+import ArticlesComponent from "../components/ArticlesComponent.vue"
+import RegisterComponent from "../components/RegisterComponent.vue";
+import LoginComponent from "../components/LoginComponent.vue";
 
 
 Vue.use(VueRouter)
@@ -9,7 +10,8 @@ Vue.use(VueRouter)
 export default new VueRouter({
   mode: 'history',
   routes: [
-    { path: "/", component: ArticlesConmponent },
-    { path: "/sign_up", component: RegisterConmponent }
+    { path: "/", component: ArticlesComponent },
+    { path: "/sign_up", component: RegisterComponent },
+    { path: "/sign_in", component: LoginComponent }
   ]
 })

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,12 +1,15 @@
 import Vue from 'vue/dist/vue.esm.js'
 import VueRouter from 'vue-router'
 import ArticlesConmponent from '../components/ArticlesConmponent.vue'
+import RegisterConmponent from "../components/RegisterConmponent.vue";
+
 
 Vue.use(VueRouter)
 
 export default new VueRouter({
   mode: 'history',
   routes: [
-    { path: '/', component: ArticlesConmponent },
-  ],
+    { path: "/", component: ArticlesConmponent },
+    { path: "/sign_up", component: RegisterConmponent }
+  ]
 })

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,6 +1,6 @@
-import Vue from 'vue/dist/vue.esm.js'
-import VueRouter from 'vue-router'
-import ArticlesComponent from "../components/ArticlesComponent.vue"
+import Vue from "vue/dist/vue.esm.js";
+import VueRouter from "vue-router";
+import ArticlesComponent from "../components/ArticlesComponent.vue";
 import RegisterComponent from "../components/RegisterComponent.vue";
 import LoginComponent from "../components/LoginComponent.vue";
 
@@ -8,10 +8,10 @@ import LoginComponent from "../components/LoginComponent.vue";
 Vue.use(VueRouter)
 
 export default new VueRouter({
-  mode: 'history',
+  mode: "history",
   routes: [
     { path: "/", component: ArticlesComponent },
     { path: "/sign_up", component: RegisterComponent },
     { path: "/sign_in", component: LoginComponent }
   ]
-})
+});

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,12 +1,12 @@
 import Vue from 'vue/dist/vue.esm.js'
 import VueRouter from 'vue-router'
-import ArticleList from '../components/ArticleList.vue'
+import ArticlesConmponent from '../components/ArticlesConmponent.vue'
 
 Vue.use(VueRouter)
 
 export default new VueRouter({
   mode: 'history',
   routes: [
-    { path: '/', component: ArticleList },
+    { path: '/', component: ArticlesConmponent },
   ],
 })

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,5 +1,5 @@
-<%= stylesheet_pack_tag 'app' %>
-<%= javascript_pack_tag 'app' %>
+<%= stylesheet_pack_tag "app" %>
+<%= javascript_pack_tag "app" %>
 <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons" rel="stylesheet">
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -2,6 +2,7 @@
 <%= javascript_pack_tag 'app' %>
 
 <div id="app">
+  <navbar></navbar>
   <div class="container">
     <router-view></router-view>
   </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,5 +1,7 @@
 <%= stylesheet_pack_tag 'app' %>
 <%= javascript_pack_tag 'app' %>
+<link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons" rel="stylesheet">
 
 <div id="app">
   <navbar></navbar>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@
 
 Rails.application.routes.draw do
   root "homes#index"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # reload 対策
+  get "sign_up", to: "homes#index"
+
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   # reload 対策
   get "sign_up", to: "homes#index"
+  get "sign_in", to: "homes#index"
 
   namespace :api do
     namespace :v1 do

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,9 +1,17 @@
-const { environment } = require('@rails/webpacker')
-const typescript =  require('./loaders/typescript')
-const { VueLoaderPlugin } = require('vue-loader')
-const vue = require('./loaders/vue')
+const { environment } = require("@rails/webpacker");
+const typescript = require("./loaders/typescript");
+const { VueLoaderPlugin } = require("vue-loader");
+const vue = require("./loaders/vue");
 
-environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
-environment.loaders.prepend('vue', vue)
-environment.loaders.prepend('typescript', typescript)
-module.exports = environment
+environment.plugins.prepend("VueLoaderPlugin", new VueLoaderPlugin());
+environment.loaders.prepend("vue", vue);
+environment.loaders.prepend("typescript", typescript);
+module.exports = environment;
+
+environment.config.merge({
+  resolve: {
+    alias: {
+      vue$: "vue/dist/vue.esm"
+    }
+  }
+});


### PR DESCRIPTION
# 概要
- トップページにヘッダーを追加 
- 新規登録ページの作成
- ログインページの作成

*新規登録 ~ ログイン ~ ログアウトの動作確認済み

<img width="1119" alt="スクリーンショット 2019-12-10 8 59 41" src="https://user-images.githubusercontent.com/30526530/70483320-75ac6f00-1b2b-11ea-9344-71bfcc3af5ea.png">


### ヘッダーのcssが正しくない表示できない問題の解決方法
app.tsに以下のコードもプラスで追記する必要があった。

`import "vuetify/dist/vuetify.min.css";`