### PR TITLE
記事の詳細ページのフロント実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,6 +9,11 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     render json: articles
   end
 
+  def show
+    article = Article.find(params[:id])
+    render json: article
+  end
+
   def create
     article = current_user.articles.create!(article_params)
     render json: article

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -1,5 +1,16 @@
 <template>
-  <v-container class="item elevation-3 articles-container"></v-container>
+  <v-container v-model="article" class="item elevation-3 article-container">
+    <v-layout xs-12 class="top-info-container">
+      <span class="user-name">@{{ article.user.name }}</span>
+      <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
+    </v-layout>
+    <v-layout>
+      <h1 class="article-title">{{ article.title }}</h1>
+    </v-layout>
+    <v-layout class="article-body-container">
+      <div id="article-body">{{ article.content }}</div>
+    </v-layout>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -14,18 +25,38 @@ import TimeAgo from "vue2-timeago";
 export default class ArticleContainer extends Vue {
   article: any = "";
   async mounted(): Promise<void> {
-    await this.fetchArticle("1");
+    await this.fetchArticle(this.$route.params.id);
   }
   async fetchArticle(id: string): Promise<void> {
-    await axios.get(`/api/v1/articles/${id}`).then(response => {
-      this.article = response.data;
-    });
+    await axios
+      .get(`/api/v1/articles/${id}`)
+      .then(response => {
+        this.article = response.data;
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.statusText);
+      });
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.articles-container {
-  margin-top: 2em;
+.top-info-container {
+  margin-bottom: 1em;
+}
+.article-container {
+  margin: 2em;
+}
+.article-title {
+  font-size: 2.5em;
+  line-height: 1.4;
+}
+.article-body-container {
+  margin: 2em 0;
+  font-size: 16px;
+}
+.user-name {
+  margin-right: 1em;
 }
 </style>

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -1,0 +1,31 @@
+<template>
+  <v-container class="item elevation-3 articles-container"></v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class ArticleContainer extends Vue {
+  article: any = "";
+  async mounted(): Promise<void> {
+    await this.fetchArticle("1");
+  }
+  async fetchArticle(id: string): Promise<void> {
+    await axios.get(`/api/v1/articles/${id}`).then(response => {
+      this.article = response.data;
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+}
+</style>

--- a/app/javascript/packs/container/ArticlesContainer.vue
+++ b/app/javascript/packs/container/ArticlesContainer.vue
@@ -1,18 +1,43 @@
 <template>
-  <div id="articles-container">
-    <ul>
-      <li v-for="article in articles" v-bind:key="article.id">
-        <div>{{article.title}}</div>
-        <div>{{article.content}}</div>
-      </li>
-    </ul>
-  </div>
+  <v-container class="item elevation-3 articles-container">
+    <v-list two-line>
+      <template v-for="(article, index) in articles">
+        <v-list-tile :key="article.title" avatar>
+          <v-list-tile-avatar>
+            <img :src="article.avatar">
+          </v-list-tile-avatar>
+
+          <v-list-tile-content>
+            <v-list-tile-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-tile-title>
+            <v-list-tile-sub-title>
+              by {{ article.user.name }}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider :key="index"></v-divider>
+      </template>
+    </v-list>
+  </v-container>
 </template>
 
 <script lang="ts">
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
-@Component
+import TimeAgo from "vue2-timeago";
+@Component({
+  components: {
+    TimeAgo
+  }
+})
 export default class ArticlesContainer extends Vue {
   articles: string[] = [];
   async mounted(): Promise<void> {
@@ -27,3 +52,22 @@ export default class ArticlesContainer extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
+}
+</style>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,6 +1,7 @@
 import Vue from "vue/dist/vue.esm.js";
 import VueRouter from "vue-router";
 import ArticlesContainer from "../container/ArticlesContainer.vue";
+import ArticleContainer from "../container/ArticleContainer.vue";
 import RegisterContainer from "../container/RegisterContainer.vue";
 import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
@@ -13,6 +14,7 @@ export default new VueRouter({
     { path: "/", component: ArticlesContainer },
     { path: "/sign_up", component: RegisterContainer },
     { path: "/sign_in", component: LoginContainer },
-    { path: "/articles/new", component: EditArticleContainer }
+    { path: "/articles/new", component: EditArticleContainer },
+    { path: "/articles/:id", component: ArticleContainer }
   ]
 });

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -15,6 +15,6 @@ export default new VueRouter({
     { path: "/sign_up", component: RegisterContainer },
     { path: "/sign_in", component: LoginContainer },
     { path: "/articles/new", component: EditArticleContainer },
-    { path: "/articles/:id", component: ArticleContainer }
+    { path: "/articles/:id", component: ArticleContainer, name: "article" }
   ]
 });

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :content, :updated_at
+  belongs_to :user
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "sign_up", to: "homes#index"
   get "sign_in", to: "homes#index"
   get "articles/new", to: "homes#index"
+  get "articles/:id", to: "homes#index"
 
   namespace :api, format: :json do
     namespace :v1 do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事の一覧が取得できる(更新順)" do
+      subject
+
+      res = JSON.parse(response.body)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
+        expect(res[0].keys).to eq ["id", "title","content", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+      end
+    end
+  end
+
+  describe "GET /articles/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    context "指定した id の記事が存在する場合" do
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
+
+      it "任意の記事の値が取得できる" do
+        subject
+
+        res = JSON.parse(response.body)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["content"]).to eq article.content
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+        end
+      end
+    end
+
+    context "指定した id の記事が存在しない場合" do
+      let(:article_id) { 10000 }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:params) { { article: attributes_for(:article) } }
+    let(:headers) { authentication_headers_for(current_user) }
+
+    it "記事のレコードが作成できる" do
+      aggregate_failures do
+        expect { subject }.to change { Article.count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "PATCH /articles/:id" do
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:params) { { article: attributes_for(:article) } }
+    let(:headers) { authentication_headers_for(current_user) }
+
+    context "自分が所持している記事のレコードを更新しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "記事を更新できる" do
+        aggregate_failures do
+          expect { subject }.to change { Article.find(article.id).title }.from(article.title).to(params[:article][:title]) &
+                                change { Article.find(article.id).content }.from(article.content).to(params[:article][:content])
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context "自分が所持していない記事のレコードを更新しようとするとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "記事が見つからない(更新できない)" do
+        aggregate_failures do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                                change { Article.count }.by(0)
+        end
+      end
+    end
+  end
+
+  describe "DELETE /articles/:id" do
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { authentication_headers_for(current_user) }
+    let(:article_id) { article.id }
+
+    context "自分が所持している記事のレコードを削除しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "記事を削除できる" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "他人が所持している記事のレコードを削除しようとするとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "記事が見つからない(削除できない)" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Articles", type: :request do
         expect(res.length).to eq 3
         expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
         expect(res[0].keys).to eq ["id", "title","content", "updated_at", "user"]
-        expect(res[0]["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+        expect(res[0]["user"].keys).to include "id", "name", "email"
       end
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe "Articles", type: :request do
           expect(res["content"]).to eq article.content
           expect(res["updated_at"]).to be_present
           expect(res["user"]["id"]).to eq article.user.id
-          expect(res["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+          expect(res["user"].keys).to include "id", "name", "email"
         end
       end
     end


### PR DESCRIPTION
# 概要
- 記事の詳細ページを作成
- 記事一覧から詳細ページへ飛べるように修正

<img width="1234" alt="スクリーンショット 2019-12-12 8 41 57" src="https://user-images.githubusercontent.com/30526530/70670047-61977780-1cbb-11ea-9850-fdc23afc8a0d.png">


<img width="1213" alt="スクリーンショット 2019-12-12 8 42 02" src="https://user-images.githubusercontent.com/30526530/70670069-6bb97600-1cbb-11ea-89fc-c02cfe9c83f0.png">
