### PR TITLE
リアルタイムプレビュー機能の実装

### DIFF
--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -10,3 +10,14 @@ body {
 #app {
   height: 100%;
 }
+
+/* highlightjs の 1行目のずれを強制 */
+
+code:before {
+  content: none !important;
+}
+
+.hljs span:first-child {
+  position: relative;
+  left: -2px;
+}

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -8,7 +8,7 @@
       <h1 class="article-title">{{ article.title }}</h1>
     </v-layout>
     <v-layout class="article-body-container">
-      <div id="article-body" v-html="compiledMarkdown"></div>
+      <div class="article-body" v-html="compiledMarkdown(article.content)"></div>
     </v-layout>
   </v-container>
 </template>
@@ -18,6 +18,7 @@ import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import TimeAgo from "vue2-timeago";
 import marked from "marked";
+import hljs from "highlight.js";
 @Component({
   components: {
     TimeAgo
@@ -28,8 +29,33 @@ export default class ArticleContainer extends Vue {
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
   }
+  async created(): Promise<void> {
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    let data = "";
+    renderer.code = function(code, lang) {
+      if (!lang || lang == "default") {
+        data = hljs.highlightAuto(code, [lang]).value;
+      } else {
+        try {
+          data = hljs.highlight(lang, code, true).value;
+        } catch (e) {
+          // Do nonthing!
+        }
+      }
+      return `<pre><code class="hljs"> ${data} </code></pre>`;
+    };
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: ""
+    });
+  }
   get compiledMarkdown() {
-    return marked(this.article.content);
+    return function(text: string) {
+      return marked(text);
+    };
   }
   async fetchArticle(id: string): Promise<void> {
     await axios
@@ -59,6 +85,9 @@ export default class ArticleContainer extends Vue {
 .article-body-container {
   margin: 2em 0;
   font-size: 16px;
+}
+.article-body {
+  width: 100%;
 }
 .user-name {
   margin-right: 1em;

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -30,18 +30,14 @@ export default class ArticleContainer extends Vue {
     await this.fetchArticle(this.$route.params.id);
   }
   async created(): Promise<void> {
-    // Add 'hljs' class to code tag
     const renderer = new marked.Renderer();
     let data = "";
     renderer.code = function(code, lang) {
-      if (!lang || lang == "default") {
-        data = hljs.highlightAuto(code, [lang]).value;
-      } else {
-        try {
-          data = hljs.highlight(lang, code, true).value;
-        } catch (e) {
-          // Do nonthing!
-        }
+      const _lang = lang.split(".").pop();
+      try {
+        data = hljs.highlight(_lang, code, true).value;
+      } catch (e) {
+        data = hljs.highlightAuto(code).value;
       }
       return `<pre><code class="hljs"> ${data} </code></pre>`;
     };

--- a/app/javascript/packs/container/EditArticleContainer.vue
+++ b/app/javascript/packs/container/EditArticleContainer.vue
@@ -39,18 +39,14 @@ export default class ArticlesContainer extends Vue {
   title: string = "";
   content: string = "";
   async created(): Promise<void> {
-    // Add 'hljs' class to code tag
     const renderer = new marked.Renderer();
     let data = "";
     renderer.code = function(code, lang) {
-      if (!lang || lang == "default") {
-        data = hljs.highlightAuto(code, [lang]).value;
-      } else {
-        try {
-          data = hljs.highlight(lang, code, true).value;
-        } catch (e) {
-          // Do nonthing!
-        }
+      const _lang = lang.split(".").pop();
+      try {
+        data = hljs.highlight(_lang, code, true).value;
+      } catch (e) {
+        data = hljs.highlightAuto(code).value;
       }
       return `<pre><code class="hljs"> ${data} </code></pre>`;
     };

--- a/app/javascript/packs/container/EditArticleContainer.vue
+++ b/app/javascript/packs/container/EditArticleContainer.vue
@@ -1,15 +1,18 @@
 <template>
   <form class="article-form">
     <v-text-field outline single-line v-model="title" name="title" label="タイトル" class="title-form"></v-text-field>
-    <v-textarea
-      outline
-      no-resize
-      height="100%"
-      v-model="content"
-      name="content"
-      label="プログラミング知識をMarkdown記法で書いて共有しよう"
-      class="body-form"
-    ></v-textarea>
+    <div class="edit-area">
+      <v-textarea
+        outline
+        no-resize
+        height="100%"
+        v-model="content"
+        name="content"
+        label="プログラミング知識をMarkdown記法で書いて共有しよう"
+        class="body-form"
+      ></v-textarea>
+      <div v-html="compiledMarkdown(this.content)" class="preview">a</div>
+    </div>
     <div class="text-xs-right">
       <v-btn @click="createArticle" color="#55c500" class="font-weight-bold white--text">Qiitaに投稿</v-btn>
     </div>
@@ -20,6 +23,8 @@
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import Router from "../router/router";
+import marked from "marked";
+import hljs from "highlight.js";
 const headers = {
   headers: {
     Authorization: "Bearer",
@@ -33,6 +38,34 @@ const headers = {
 export default class ArticlesContainer extends Vue {
   title: string = "";
   content: string = "";
+  async created(): Promise<void> {
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    let data = "";
+    renderer.code = function(code, lang) {
+      if (!lang || lang == "default") {
+        data = hljs.highlightAuto(code, [lang]).value;
+      } else {
+        try {
+          data = hljs.highlight(lang, code, true).value;
+        } catch (e) {
+          // Do nonthing!
+        }
+      }
+      return `<pre><code class="hljs"> ${data} </code></pre>`;
+    };
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: ""
+    });
+  }
+  get compiledMarkdown() {
+    return function(text: string) {
+      return marked(text);
+    };
+  }
   async createArticle(): Promise<void> {
     const params = {
       title: this.title,
@@ -60,6 +93,20 @@ export default class ArticlesContainer extends Vue {
 }
 .title-form {
   flex: none;
+}
+.edit-area {
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+}
+.preview {
+  width: 50%;
+  padding: 12px;
+  margin-bottom: 8px;
+  border: 2px solid rgba(0, 0, 0, 0.54);
+  border-radius: 4px;
+  border-left: none;
+  overflow: auto;
 }
 </style>
 


### PR DESCRIPTION
# 概要
- Markdown のリアルタイムプレビューを実装
- Syntax Highlight が想定通りの動作をしていなかったため、指定した lang のハイライトがされるように調整

# イメージ

<img width="1233" alt="スクリーンショット 2019-12-14 15 04 30" src="https://user-images.githubusercontent.com/30526530/70844339-23e54b00-1e83-11ea-9b13-92ad1e4edf05.png">
