### PR TITLE
WIP:【Task.11-2 既存のAPIの修正】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   end
 
   def show
-    article = Article.find(params[:id])
-    render json: article if article.published?
+    article = Article.published.find(params[:id])
+    render json: article
   end
 
   def create

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: %i[create update destroy]
 
   def index
-    articles = Article.all.where(status: "published")
+    articles = Article.published
     render json: articles
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,13 +5,13 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: %i[create update destroy]
 
   def index
-    articles = Article.all
+    articles = Article.all.where(status: "published")
     render json: articles
   end
 
   def show
     article = Article.find(params[:id])
-    render json: article
+    render json: article if article.published?
   end
 
   def create
@@ -31,7 +31,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   private
 
   def article_params
-    params.require(:article).permit(:title, :content)
+    params.require(:article).permit(:title, :content, :status)
   end
 
   def set_article

--- a/app/controllers/api/v1/drafts_controller.rb
+++ b/app/controllers/api/v1/drafts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::DraftsController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: [:index]
 
   def index
-    articles = current_user.articles.where(status: "draft")
+    articles = current_user.articles.draft
     render json: articles
   end
 

--- a/app/controllers/api/v1/drafts_controller.rb
+++ b/app/controllers/api/v1/drafts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::DraftsController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: [:index]
 
   def index
-    articles = current_user.articles.where(status: 0)
+    articles = current_user.articles.where(status: "draft")
     render json: articles
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     user
   end
 
-  trait :with_published_article do
+  trait :published do
     status {:published}
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Article, type: :model do
   describe "正常系" do
     let!(:user) {create(:user)}
     let!(:article)  { create(:article, user_id: user.id) }
-    let!(:article2) { create(:article, status: 1, user_id: user.id) }
+    let!(:article2) { create(:article, :with_published_article, user_id: user.id) }
 
-    context "statusカラムの値が1のレコードを検索した時" do
+    context "statusカラムの値が「publishe」のレコードを検索した時" do
       it "公開記事が返される" do
-        expect(user.articles.where(status: 1).count).to eq 1
+        expect(Article.published.count).to eq 1
       end
     end
 
-    context "statusカラムの値が0の記事を指定した時" do
+    context "statusカラムの値が「draft」の記事を指定した時" do
       it "下書き記事が返される" do
-        expect(user.articles.where(status: 0).count).to eq 1
+        expect(Article.draft.count).to eq 1
       end
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Article, type: :model do
   describe "正常系" do
     let!(:user) {create(:user)}
     let!(:article)  { create(:article, user_id: user.id) }
-    let!(:article2) { create(:article, :with_published_article, user_id: user.id) }
+    let!(:article2) { create(:article, :published, user_id: user.id) }
 
     context "statusカラムの値が「published」のレコードを検索した時" do
       it "公開記事が返される" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Article, type: :model do
 
     context "statusカラムの値が「published」のレコードを検索した時" do
       it "公開記事が返される" do
-        expect(Article.published.count).to eq 1
+        expect(user.articles.published.count).to eq 1
       end
     end
 
     context "statusカラムの値が「draft」の記事を指定した時" do
       it "下書き記事が返される" do
-        expect(Article.draft.count).to eq 1
+        expect(user.articles.draft.count).to eq 1
       end
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Article, type: :model do
     let!(:article)  { create(:article, user_id: user.id) }
     let!(:article2) { create(:article, :with_published_article, user_id: user.id) }
 
-    context "statusカラムの値が「publishe」のレコードを検索した時" do
+    context "statusカラムの値が「published」のレコードを検索した時" do
       it "公開記事が返される" do
         expect(Article.published.count).to eq 1
       end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, :with_published_article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, :with_published_article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article, :with_published_article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
     it "記事の一覧が取得できる(更新順)" do
       subject
 
@@ -26,7 +26,7 @@ RSpec.describe "Articles", type: :request do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定した id の記事が存在する場合" do
-      let(:article) { create(:article, :with_published_article) }
+      let(:article) { create(:article, :published) }
       let(:article_id) { article.id }
 
       it "任意の記事の値が取得できる" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Articles", type: :request do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定した id の記事が存在する場合" do
-      let(:article) { create(:article) }
+      let(:article) { create(:article, :with_published_article) }
       let(:article_id) { article.id }
 
       it "任意の記事の値が取得できる" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
-
+    let!(:article1) { FactoryBot.create(:article, :with_published_article, updated_at: 1.days.ago) }
+    let!(:article2) { FactoryBot.create(:article, :with_published_article, updated_at: 2.days.ago) }
+    let!(:article3) { FactoryBot.create(:article, :with_published_article) }
     it "記事の一覧が取得できる(更新順)" do
       subject
 
@@ -17,7 +16,7 @@ RSpec.describe "Articles", type: :request do
         expect(response).to have_http_status(:ok)
         expect(res.length).to eq 3
         expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
-        expect(res[0].keys).to eq ["id", "title","content", "updated_at", "user"]
+        expect(res[0].keys).to eq ["id", "title","content", "updated_at", "status", "user"]
         expect(res[0]["user"].keys).to include "id", "name", "email"
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { FactoryBot.create(:article, :with_published_article, updated_at: 1.days.ago) }
-    let!(:article2) { FactoryBot.create(:article, :with_published_article, updated_at: 2.days.ago) }
-    let!(:article3) { FactoryBot.create(:article, :with_published_article) }
+    let!(:article1) { create(:article, :with_published_article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :with_published_article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :with_published_article) }
     it "記事の一覧が取得できる(更新順)" do
       subject
 

--- a/spec/requests/api/v1/drafts_spec.rb
+++ b/spec/requests/api/v1/drafts_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Drafts", type: :request do
     let!(:user) {create(:user)}
     let!(:article)  { create(:article, user_id: user.id) }
     let!(:article2) { create(:article, user_id: user.id) }
-    let!(:article3) { create(:article, status: 1, user_id: user.id) }
+    let!(:article3) { create(:article, :with_published_article, user_id: user.id) }
 
     context "ログインしている時" do
 
@@ -25,7 +25,7 @@ RSpec.describe "Drafts", type: :request do
         end
 
         get (api_v1_drafts_index_path)
-        expect(user.articles.where(status: 0).count).to eq 2
+        expect(user.articles.draft.count).to eq 2
       end
     end
 

--- a/spec/requests/api/v1/drafts_spec.rb
+++ b/spec/requests/api/v1/drafts_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Drafts", type: :request do
     let!(:user) {create(:user)}
     let!(:article)  { create(:article, user_id: user.id) }
     let!(:article2) { create(:article, user_id: user.id) }
-    let!(:article3) { create(:article, :with_published_article, user_id: user.id) }
+    let!(:article3) { create(:article, :published, user_id: user.id) }
 
     context "ログインしている時" do
 


### PR DESCRIPTION
# 概要
- 公開されている記事だけ取得できるようにする
- 記事を作成する場合は、記事の公開/非公開を選択できるようにする

## 質問
#### 「記事を作成する場合は、記事の公開/非公開を選択できるようにする」
上記部分は、以下手順で実装したのですが
やっていることとして合っているのかわかっていません汗
ご確認と、ヒントをいただけると幸いでございます。

#### ①ストロングパラメータにdraftを追加。
#### ②articles#createアクションででstatusのパラメータも込みで受け取って保存。
#### ③indexアクションでpublishedの記事のみを返す。
#### ④showも同様にpublishedのもののみ返す。
